### PR TITLE
Harden GUI against XSS, CSRF, and settings-file loss

### DIFF
--- a/ai_remaster_gui/http_handler.py
+++ b/ai_remaster_gui/http_handler.py
@@ -112,11 +112,26 @@ class Handler(BaseHTTPRequestHandler):
                 return (urlparse(value).hostname or "").lower() in LOOPBACK_HOSTNAMES
         return True  # same-origin requests may omit both; the Host check still applies
 
+    # GET endpoints that mutate state (spawn preview/crop subprocesses, write cache files) rather
+    # than being pure reads. These get the same cross-origin guard do_POST applies.
+    SIDE_EFFECT_GET_PATHS = frozenset({
+        "/api/shot-preview",
+        "/api/aspect-preview",
+        "/api/outpaint-auto-crop",
+        "/api/outpaint-chunk-preview",
+        "/api/outpaint-guide-preview",
+    })
+
     def do_GET(self) -> None:  # noqa: N802
         if not self.request_host_is_local():
             self.send_error(403)
             return
         parsed = urlparse(self.path)
+        # A page on another site can issue a simple cross-origin GET with no preflight. Block those
+        # from triggering the side-effecting endpoints (CSRF), the same way do_POST is protected.
+        if parsed.path in self.SIDE_EFFECT_GET_PATHS and not self.request_origin_is_local():
+            self.send_error(403)
+            return
         if parsed.path == "/":
             self.send_static(STATIC_DIR / "index.html", "text/html; charset=utf-8")
         elif parsed.path.startswith("/static/"):

--- a/ai_remaster_gui/server.py
+++ b/ai_remaster_gui/server.py
@@ -401,7 +401,13 @@ class PipelineApp:
         return values.get("outpainted_video", "") or values.get("source", "") or pipeline_source_text(self.settings)
 
     def save(self) -> None:
-        SETTINGS_FILE.write_text(json.dumps(self.settings, indent=2) + "\n", encoding="utf-8")
+        # Write to a sibling temp file and atomically replace it in. A concurrent reader (or a
+        # second saver) can then never observe a half-written file and silently lose the project
+        # config on the next load. os.replace is atomic on the same filesystem.
+        payload = json.dumps(self.settings, indent=2) + "\n"
+        tmp = SETTINGS_FILE.with_name(f"{SETTINGS_FILE.name}.tmp-{os.getpid()}-{threading.get_ident()}")
+        tmp.write_text(payload, encoding="utf-8")
+        os.replace(tmp, SETTINGS_FILE)
 
     def files_for(self, stage: Stage) -> list[dict[str, str | int]]:
         exts = VIDEO_EXTS | IMAGE_EXTS | TEXT_EXTS
@@ -730,6 +736,15 @@ class PipelineApp:
         return payload
 
     def update_settings(self, stage: str, values: dict[str, str]) -> None:
+        # Serialise settings mutations against readers: state() serialises self.settings under this
+        # same lock, so an unlocked writer here can trip "dictionary changed size during iteration"
+        # in the /api/state json.dumps and 500 the polling endpoint. Helpers called below
+        # (clear_derived_stage_inputs, hydrate_stage_inputs, save) do not take self.lock, so this
+        # non-reentrant lock is safe to hold across them.
+        with self.lock:
+            self._apply_settings_update(stage, values)
+
+    def _apply_settings_update(self, stage: str, values: dict[str, str]) -> None:
         previous_source = self.settings.get("global", {}).get("source", "") if stage == "global" else ""
         if stage == "global" and "source" in values:
             source = resolve_video_source(str(values.get("source", "")))
@@ -1055,7 +1070,7 @@ class PipelineApp:
         }
 
     def command_for(self, stage_key: str) -> list[str]:
-        values = self.settings[stage_key]
+        values = self.settings.get(stage_key, {})
         config = current_config()
         builder = self._stage_command_builders().get(stage_key)
         cmd = builder(config, values) if builder else [sys.executable, "-u"]
@@ -1836,7 +1851,15 @@ state.APP = APP  # register the singleton so sibling modules can reach it withou
 
 
 def _outpaint_crop_black(values: dict[str, str]) -> tuple[list[int], bool]:
-    crop = [int(float(values.get(key, "0") or 0)) for key in ("crop_left", "crop_right", "crop_top", "crop_bottom")]
+    def _crop(key: str) -> int:
+        # Settings arrive as raw strings; a non-numeric crop value must not raise here, since this
+        # runs inside expected_outputs()/state() and would otherwise 500 the whole /api/state view.
+        try:
+            return int(float(values.get(key, "0") or 0))
+        except (TypeError, ValueError):
+            return 0
+
+    crop = [_crop(key) for key in ("crop_left", "crop_right", "crop_top", "crop_bottom")]
     black = is_true(values, "outpaint_all_black_regions")
     return crop, black
 

--- a/ai_remaster_gui/static/js/actions.js
+++ b/ai_remaster_gui/static/js/actions.js
@@ -1648,7 +1648,9 @@ async function browseField(stageKey, fieldKey, kind) {
 async function showCommand(key) {
   const result = await api('/api/command?stage=' + encodeURIComponent(key));
   const el = document.getElementById('cmd');
-  if (el) el.textContent = result.command.join(' ');
+  if (!el) return;
+  if (Array.isArray(result.command)) el.textContent = result.command.join(' ');
+  else el.textContent = result.error ? `Error: ${result.error}` : '';
 }
 
 async function confirmOverwrite(key) {

--- a/ai_remaster_gui/static/js/core.js
+++ b/ai_remaster_gui/static/js/core.js
@@ -20,11 +20,25 @@ const stateUrl = (options = {}) => {
 };
 
 async function api(path, opts = {}) {
-  const response = await fetch(path, {
-    headers: { 'Content-Type': 'application/json' },
-    ...opts,
-  });
-  return await response.json();
+  let response;
+  try {
+    response = await fetch(path, {
+      headers: { 'Content-Type': 'application/json' },
+      ...opts,
+    });
+  } catch (err) {
+    return { ok: false, error: 'Could not reach the ARP server. Is it still running?' };
+  }
+  let data;
+  try {
+    data = await response.json();
+  } catch (err) {
+    return { ok: false, error: `The server returned an unexpected response (HTTP ${response.status}).` };
+  }
+  if (!response.ok && data && typeof data === 'object' && data.error === undefined) {
+    data.error = `Request failed (HTTP ${response.status}).`;
+  }
+  return data;
 }
 
 async function refresh(force = false) {
@@ -35,7 +49,9 @@ async function refresh(force = false) {
 
   const appHasContent = !!document.getElementById('app')?.children.length;
   const useCachedShotPreviews = !force && active === 'shots' && appHasContent;
-  state = await api(stateUrl({ shotPreviews: useCachedShotPreviews ? 'cached' : 'generate' }));
+  const nextState = await api(stateUrl({ shotPreviews: useCachedShotPreviews ? 'cached' : 'generate' }));
+  if (!nextState || !Array.isArray(nextState.stages)) return; // transient server error: keep the last good state and retry next poll
+  state = nextState;
   pruneSelected();
   if (!availableTabs().includes(active)) active = 'global';
   notifyNewLogErrors();
@@ -389,7 +405,14 @@ async function selectTab(tab) {
   drawTabs();
   if (tab === 'outpaint') showOutpaintLoadingShell();
   else if (['shots', 'references', 'colour'].includes(tab)) showShotLoadingShell(tab);
-  state = await api(stateUrl());
+  const nextState = await api(stateUrl());
+  if (!nextState || !Array.isArray(nextState.stages)) {
+    // Server error while loading the tab; re-render the last good view instead of a stuck spinner.
+    drawTabs();
+    draw(false);
+    return;
+  }
+  state = nextState;
   pruneSelected();
   drawTabs();
   draw(false);

--- a/ai_remaster_gui/static/js/render-helpers.js
+++ b/ai_remaster_gui/static/js/render-helpers.js
@@ -107,6 +107,7 @@ function fieldHelpHtml(help) {
 }
 
 function fieldHtml(st, field) {
+  if (!field) return ''; // a stage config missing an expected field must not blank the whole tab
   const [key, label, kind, defaultValue] = field;
   const value = settings(st.key)[key] ?? defaultValue ?? '';
   const help = fieldDescription(st.key, key);
@@ -340,7 +341,7 @@ function fileRow(st, file) {
   const emptyClass = thumb ? '' : 'no-thumb';
 
   return `
-    <div class="file ${emptyClass}" onclick="selected['${st.key}']='${esc(file.path)}';draw()">
+    <div class="file ${emptyClass}" onclick="selected[${jsArg(st.key)}]=${jsArg(file.path)};draw()">
       ${thumb}
       <div class="file-path">${esc(file.path)}</div>
     </div>

--- a/ai_remaster_gui/static/js/render-recomp.js
+++ b/ai_remaster_gui/static/js/render-recomp.js
@@ -320,7 +320,7 @@ function colorLayerStyle(s) {
   const rawOpacity = Math.max(0, Number(s.color_opacity || 100));
   const opacity = Math.max(0, Math.min(1, rawOpacity > 1 ? rawOpacity / 100 : rawOpacity));
   const hue = Math.max(-18, Math.min(18, (6500 - temp) / 180));
-  return `filter:saturate(${saturation});opacity:${opacity};hue-rotate(${hue}deg)`;
+  return `filter:saturate(${saturation}) hue-rotate(${hue}deg);opacity:${opacity}`;
 }
 
 function originalFeatherStyle(s) {

--- a/ai_remaster_gui/static/js/render-shots.js
+++ b/ai_remaster_gui/static/js/render-shots.js
@@ -166,7 +166,7 @@ function shotSummary({ manifest, row, idx, enabled }, extra = '') {
       <div class="shot-number">Shot ${idx + 1}</div>
       <div class="shot-time">${esc(row.start_label)} to ${esc(row.end_label)}</div>
       <label>
-        <input type="checkbox" ${enabled ? 'checked' : ''} onchange="saveShotEnabled('${esc(manifest)}',${idx},this.checked)">
+        <input type="checkbox" ${enabled ? 'checked' : ''} onchange="saveShotEnabled(${jsArg(manifest)},${idx},this.checked)">
         Use shot
       </label>
       ${extra}
@@ -208,7 +208,7 @@ function shotTransitionControl(mode, manifest, row) {
           type="checkbox"
           id="fade_${row.index}"
           ${checked ? 'checked' : ''}
-          onchange="saveShotFade('${esc(manifest)}',${row.index},this.checked,document.getElementById('crossfade_${row.index}').value)"
+          onchange="saveShotFade(${jsArg(manifest)},${row.index},this.checked,document.getElementById('crossfade_${row.index}').value)"
         >
         Fading transition
       </label>
@@ -220,7 +220,7 @@ function shotTransitionControl(mode, manifest, row) {
           min="0.041"
           step="0.041"
           value="${esc(value)}"
-          onchange="saveShotFade('${esc(manifest)}',${row.index},document.getElementById('fade_${row.index}')?.checked ?? ${checked},this.value)"
+          onchange="saveShotFade(${jsArg(manifest)},${row.index},document.getElementById('fade_${row.index}')?.checked ?? ${checked},this.value)"
         >
       </label>
     </div>
@@ -255,12 +255,12 @@ function boundaryFrameCard({ manifest, row, idx }, edge) {
         data-edge="${edge}"
         data-fps="${fps}"
         data-preview-offset-frames="${previewOffsetFrames}"
-        oninput="updateShotBoundaryPreview('${esc(manifest)}',${idx},this.value,'${imgId}','${labelId}',this.dataset)"
-        onchange="setShotBoundary('${esc(manifest)}',${idx},'${edge}',this.value)"
+        oninput="updateShotBoundaryPreview(${jsArg(manifest)},${idx},this.value,'${imgId}','${labelId}',this.dataset)"
+        onchange="setShotBoundary(${jsArg(manifest)},${idx},'${edge}',this.value)"
       >
       <div class="shot-tools">
-        <button type="button" ${disabled} onclick="nudgeShotBoundary('${esc(manifest)}',${idx},'${edge}',-1)">-1 frame</button>
-        <button type="button" ${disabled} onclick="nudgeShotBoundary('${esc(manifest)}',${idx},'${edge}',1)">+1 frame</button>
+        <button type="button" ${disabled} onclick="nudgeShotBoundary(${jsArg(manifest)},${idx},'${edge}',-1)">-1 frame</button>
+        <button type="button" ${disabled} onclick="nudgeShotBoundary(${jsArg(manifest)},${idx},'${edge}',1)">+1 frame</button>
       </div>
     </div>
   `;
@@ -316,7 +316,7 @@ function referenceCard(context) {
       ${shotSummary(context, referenceTimeControl(manifest, row, idx, slider, label, img))}
       <div>
         <label>B&W screenshot</label>
-        ${sourceReady ? `<div class="thumb-wrap"><img id="${img}" src="${sourceUrl}" alt="" onclick="openImageModal(this.src,${jsArg('B&W screenshot')})"><button class="icon-button" type="button" title="Save B&W screenshot" onclick="exportMedia('${esc(row.source_reference)}')">&#128190;</button></div>` : missingImage('Image not present')}
+        ${sourceReady ? `<div class="thumb-wrap"><img id="${img}" src="${sourceUrl}" alt="" onclick="openImageModal(this.src,${jsArg('B&W screenshot')})"><button class="icon-button" type="button" title="Save B&W screenshot" onclick="exportMedia(${jsArg(row.source_reference)})">&#128190;</button></div>` : missingImage('Image not present')}
       </div>
       <div>
         <label>Color reference</label>
@@ -388,7 +388,7 @@ function referenceTimeControl(manifest, row, idx, slider, label, img) {
       data-reference-time-slider="true"
       data-shot-index="${idx}"
       data-fps="${fps}"
-      oninput="this.dataset.referenceTimeDirty='true';updateShotPreview('${esc(manifest)}',${idx},this.value,'${img}','${label}',Math.round(Number(this.value) * Number(this.dataset.fps || 24)))"
+      oninput="this.dataset.referenceTimeDirty='true';updateShotPreview(${jsArg(manifest)},${idx},this.value,'${img}','${label}',Math.round(Number(this.value) * Number(this.dataset.fps || 24)))"
     >
     <div class="shot-time" id="${label}">${esc(row.selected_label)}</div>
   `;
@@ -397,9 +397,9 @@ function referenceTimeControl(manifest, row, idx, slider, label, img) {
 function colorReferenceThumb(manifest, idx, colorUrl, row) {
   return `
     <div class="thumb-wrap">
-      <img src="${colorUrl}" alt="" onclick="openReferenceEditor('${esc(manifest)}',${idx})" title="Open advanced reference editor">
+      <img src="${colorUrl}" alt="" onclick="openReferenceEditor(${jsArg(manifest)},${idx})" title="Open advanced reference editor">
       ${row.color_reference_edited ? '<span class="edit-badge">Edited</span>' : ''}
-      <button class="icon-button" type="button" title="Delete color reference" onclick="deleteReference('${esc(manifest)}',${idx})">&#128465;</button>
+      <button class="icon-button" type="button" title="Delete color reference" onclick="deleteReference(${jsArg(manifest)},${idx})">&#128465;</button>
     </div>
   `;
 }
@@ -412,12 +412,12 @@ function referencePromptTools({ manifest, row, idx }) {
 
   return `
     <label>Shot prompt</label>
-    <textarea data-shot-prompt="${idx}" onblur="saveShotPrompt('${esc(manifest)}',${idx},this.value)" placeholder="Optional extra direction for this shot">${esc(row.prompt || '')}</textarea>
+    <textarea data-shot-prompt="${idx}" onblur="saveShotPrompt(${jsArg(manifest)},${idx},this.value)" placeholder="Optional extra direction for this shot">${esc(row.prompt || '')}</textarea>
     <div class="shot-tools">
-      <button type="button" onclick="chooseCustomReference('${esc(manifest)}',${idx})">
+      <button type="button" onclick="chooseCustomReference(${jsArg(manifest)},${idx})">
         Use Custom Image
       </button>
-      <button type="button" onclick="regenerateReference('${esc(manifest)}',${idx})" ${state.running ? 'disabled' : ''}>
+      <button type="button" onclick="regenerateReference(${jsArg(manifest)},${idx})" ${state.running ? 'disabled' : ''}>
         ${regenerating ? 'Generating...' : 'Generate Reference'}
       </button>
       ${regenerating ? '<span class="spinner" aria-label="In progress"></span>' : ''}
@@ -465,7 +465,7 @@ function wireReferenceTimeControls() {
     }
 
     tools.innerHTML = `
-      <button type="button" onclick="scrubShot('${esc(manifest)}',${row.index},document.getElementById('shotSlider_references_${row.index}').value,Math.round(Number(document.getElementById('shotSlider_references_${row.index}').value) * ${Math.max(1, Number(row.fps || 24))}))">
+      <button type="button" onclick="scrubShot(${jsArg(manifest)},${row.index},document.getElementById('shotSlider_references_${row.index}').value,Math.round(Number(document.getElementById('shotSlider_references_${row.index}').value) * ${Math.max(1, Number(row.fps || 24))}))">
         Use Frame
       </button>
     `;

--- a/ai_remaster_gui/system_status.py
+++ b/ai_remaster_gui/system_status.py
@@ -202,7 +202,7 @@ def vram_status() -> dict:
                 percent = int(round((used / total) * 100)) if total else 0
                 payload = memory_payload("VRAM", used, total, percent)
                 payload["detail"] = f"{payload['detail']} - {name} - {util_text}% GPU utilization"
-                payload["gpu_utilization"] = int(util_text)
+                payload["gpu_utilization"] = int(util_text) if util_text.isdigit() else None
                 payload["gpu_name"] = name
                 return payload
         except Exception as exc:

--- a/scripts/outpaint_video.py
+++ b/scripts/outpaint_video.py
@@ -1460,8 +1460,8 @@ def main() -> int:
                 if chunk_negative_suffix:
                     print(f"Chunk {chunk_index + 1} negative suffix: {chunk_negative_suffix}", flush=True)
                 if guide_image:
-                    source = "explicit" if explicit_guide else "auto"
-                    print(f"Chunk {chunk_index + 1} start guide ({source}): {guide_image}", flush=True)
+                    guide_source = "explicit" if explicit_guide else "auto"
+                    print(f"Chunk {chunk_index + 1} start guide ({guide_source}): {guide_image}", flush=True)
                 for gf in extra_guides:
                     print(f"Chunk {chunk_index + 1} guide frame_idx={gf['frame_idx']}: {gf['image']}", flush=True)
                 prompt = patch_workflow(args, workflow, chunk_prepared, comfy_dir, chunk_prefix, prompt_text, negative_text, chunk_seed, guide_image, extra_guides)


### PR DESCRIPTION
## Hi! First off, we love this project 🎬

We came across ARP while looking for a serious, local-first film remastering pipeline, and honestly it's one of the most thoughtfully built ones we've seen. The staged approach, the deterministic resume, the signature sidecars, the fact that every subprocess call uses list-form args and paths are properly allowlisted, this is careful, defensive code. It clearly comes from someone who cares. Thank you for building it in the open.

While reading through it we spotted a small set of bugs and thought the friendly thing to do was fix them and send them your way rather than just file issues. **Please review everything carefully before merging** (we couldn't run your test suite in our environment, so we verified by reading the code, `py_compile`, and `node --check`, and we made sure the existing route-coverage and http-security test contracts still hold). If you disagree with any of it, no hard feelings at all, feel free to take the parts you like and drop the rest.

Everything here is small and surgical: **9 files, +95/-31**, no changes to the normal happy path.

### What we found, in plain terms

**1. Filenames with a quote in them could break the UI, or run code (XSS).**
A few buttons/sliders build their `onclick` from a file path or manifest path using `esc()`. The catch: `esc()` turns a `'` into `&#39;`, and inside an HTML attribute the browser turns it *back* into a real `'` before the JavaScript runs, which re-opens the string. So a file literally named `O'Brien.png` breaks that control, and a maliciously named file in imported footage could run arbitrary JS on click. Your codebase already has the right helper for this (`jsArg()`, used correctly elsewhere), so we just switched these spots over to it.

**2. Another website could quietly trigger work on your machine (CSRF).**
Your POST endpoints already reject requests coming from another site. The GET endpoints didn't, and a few of them do real work (spawn preview/crop subprocesses, write files). So a random tab open in the same browser could poke `127.0.0.1` and make ARP start processing. We added the same origin check you already use for POSTs to just those side-effecting GETs.

**3. The settings file could get corrupted and silently wiped.**
`save()` wrote the JSON in place. Because the server is multi-threaded, two saves landing at once could leave a half-written file, and on next start `load_settings()` quietly discards invalid JSON, so the whole project config vanishes with no error. We changed `save()` to write a temp file and atomically swap it in.

**4. Saving settings while the UI polls could 500 the app.**
`state()` reads the settings dict under a lock, but `update_settings()` was changing it without one, so a save landing mid-poll could raise `dictionary changed size during iteration` and break `/api/state`. We put the update under the same lock (the helpers it calls don't take that lock, so no deadlock).

**5. A few smaller robustness fixes:**
- A non-numeric crop value threw and broke `/api/state` until the settings file was hand-edited, now parsed safely.
- `command_for()` with an unknown stage raised `KeyError`, now uses `.get()`.
- `api()` didn't check `response.ok` and always parsed JSON, so any non-JSON error left a tab stuck on the spinner; it now returns a clean error and the UI keeps the last good state.
- `showCommand()` / `fieldHtml()` could throw and blank a tab on an error response or missing field; both degrade gracefully now.
- On GPUs where `nvidia-smi` reports `[N/A]` utilization (many laptops), the whole VRAM panel disappeared; now guarded.
- In the color preview, `hue-rotate()` was sitting outside the `filter:` value, so the temperature tint was silently ignored, moved it inside.
- Renamed a loop variable that was shadowing the source-video `Path` (harmless today, but a trap for future edits).

### Notes
- We deliberately left the `/api/comfy` connectivity probe and the in-memory ffprobe cache alone. The first looks intentional (you need to reach the ComfyUI URL the user configures) and the second is only a slow-growth concern in very long sessions, happy to send a follow-up if you'd like a bounded cache.
- It's a single atomic commit grouped by theme (security / data-loss / robustness) in the message; happy to split it into separate commits if that's easier for you to review.

Thanks again for the project, and thanks for reading this far. 🙏
